### PR TITLE
use substring instead of split for headers with empty values

### DIFF
--- a/brokerModule/src/main/java/org/assimbly/broker/converter/CompositeDataConverter.java
+++ b/brokerModule/src/main/java/org/assimbly/broker/converter/CompositeDataConverter.java
@@ -102,8 +102,8 @@ public class CompositeDataConverter {
                             String headerValue;
 
                             if(property.contains("=")) {
-                                headerKey = property.split("=")[0];
-                                headerValue = property.split("=")[1];
+                                headerKey = property.substring(0, property.indexOf('='));
+                                headerValue = property.substring(property.indexOf('=') + 1);
                                 if(headerKey.startsWith("JMS")){
                                     jmsheaders.put(headerKey,headerValue);
                                 }else{


### PR DESCRIPTION
use substring instead of split for headers with empty values