### PR TITLE
bind saxonXPathFactory as XPathFactory type in Camel registry to ensu…

### DIFF
--- a/integration/src/main/java/org/assimbly/integration/impl/CamelIntegration.java
+++ b/integration/src/main/java/org/assimbly/integration/impl/CamelIntegration.java
@@ -318,7 +318,7 @@ public class CamelIntegration extends BaseIntegration {
 		registry.bind("AttachmentAttacher",new org.assimbly.mail.component.mail.AttachmentAttacher());
 		registry.bind("CurrentAggregateStrategy", new AggregateStrategy());
 		registry.bind("CurrentEnrichStrategy", new EnrichStrategy());
-		registry.bind("saxonXPathFactory", new net.sf.saxon.xpath.XPathFactoryImpl());
+		registry.bind("saxonXPathFactory", javax.xml.xpath.XPathFactory.class, new net.sf.saxon.xpath.XPathFactoryImpl());
 		registry.bind("CustomHttpHeaderFilterStrategy",new CustomHttpHeaderFilterStrategy());
 		registry.bind("customHttpBinding", new CustomHttpBinding());
 		registry.bind("exceptionAsJson", new ExceptionAsJsonProcessor());


### PR DESCRIPTION
…re Saxon is always used for XPath splitting