### PR TITLE
lastFailed from the new getLastExchangeFailureHandledTimestamp method

### DIFF
--- a/integration/src/main/java/org/assimbly/integration/impl/manager/StatsManager.java
+++ b/integration/src/main/java/org/assimbly/integration/impl/manager/StatsManager.java
@@ -170,7 +170,7 @@ public class StatsManager {
         if (fullStats) {
             stats.uptimeMillis = managedRouteGroup.getUptimeMillis();
             stats.uptime = managedRouteGroup.getUptime();
-            stats.lastFailed = managedRouteGroup.getLastExchangeFailureTimestamp() != null ? managedRouteGroup.getLastExchangeFailureTimestamp().getTime() : 0L;
+            stats.lastFailed = managedRouteGroup.getLastExchangeFailureHandledTimestamp() != null ? managedRouteGroup.getLastExchangeFailureHandledTimestamp().getTime() : 0L;
             stats.lastCompleted = managedRouteGroup.getLastExchangeCompletedTimestamp() != null ? managedRouteGroup.getLastExchangeCompletedTimestamp().getTime() : 0L;
         }
 


### PR DESCRIPTION
issue: [#6424](https://github.com/fluxygen/front-end/issues/6424)